### PR TITLE
Release: Google credentials management

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: python manage.py init_flask_instance
 web: gunicorn jsth.wsgi:app

--- a/jsth/api.py
+++ b/jsth/api.py
@@ -40,7 +40,7 @@ def load_geojson(filename):
 @api_bp.route('/auth/google/callback', methods=['GET'])
 def google_auth_callback():
     flow = Flow.from_client_secrets_file(
-        os.path.join('instance', 'google_credentials.json'),
+        os.path.join(app.instance_path, app.config['GOOGLE_CREDENTIALS_FILE']),
         scopes=['https://www.googleapis.com/auth/photoslibrary.readonly'],
     )
 

--- a/jsth/config.py
+++ b/jsth/config.py
@@ -16,6 +16,7 @@ class Config(object):
     DEBUG = True
     CSRF_ENABLED = True
     SECRET_KEY = os.getenv('SECRET_KEY')
+    GOOGLE_CREDENTIALS_FILE = 'google_credentials.json'
 
     DATABASE = 'jsth.sqlite'
 

--- a/jsth/routes.py
+++ b/jsth/routes.py
@@ -65,6 +65,7 @@ def register_routes(app):
             return render_template('photo-gallery.html', media=media)
 
         authorization_url = utils.google_auth()
+
         return redirect(authorization_url)
 
     @app.route('/contact', methods=['GET'])

--- a/jsth/utils.py
+++ b/jsth/utils.py
@@ -73,7 +73,7 @@ def google_auth():
     Handles authentication of the Google Photos API.
     '''
     flow = Flow.from_client_secrets_file(
-        os.path.join('instance', 'google_credentials.json'),
+        os.path.join(app.instance_path, app.config['GOOGLE_CREDENTIALS_FILE']),
         scopes=['https://www.googleapis.com/auth/photoslibrary.readonly']
     )
 

--- a/release.py
+++ b/release.py
@@ -1,0 +1,30 @@
+'''
+The release module contains functions that will be executed during
+Heroku's release phase. This includes some flask specific tasks
+like ensuring the instance directory exists, and application tasks
+like running database migrations. It'll be pretty empty to start out.
+'''
+
+
+import os
+
+
+def release():
+    '''
+    Runs Heroku release phase tasks.
+    '''
+    if not os.path.exists('instance'):
+        os.makedirs('instance')
+
+    with open('instance/google_credentials.json', 'w') as fh:
+        fh.write(os.getenv('GOOGLE_CREDENTIALS'))
+
+
+def db_migrate():
+    '''
+    Runs migrations on the application database.
+    '''
+
+
+if __name__ == '__main__':
+    release()


### PR DESCRIPTION
Add google credentials to the instance directory during Heroku's release phase. The credentials file content is stored locally in the `.env` file and as a config variable on Heroku.