### PR TITLE
Better handling of google credentials.

### DIFF
--- a/jsth/__init__.py
+++ b/jsth/__init__.py
@@ -68,7 +68,3 @@ def create_instance_dir(app):
         os.makedirs(app.instance_path)
     else:
         app.logger.info('instance directory found!')
-
-    app.logger.info('writing google credentials to instance directory...')
-    with open(f'{app.instance_path}/google_credentials.json', 'w') as fh:
-        fh.write(os.getenv('GOOGLE_CREDENTIALS'))

--- a/jsth/api.py
+++ b/jsth/api.py
@@ -4,6 +4,7 @@ for tasks like loading files or generating access tokens.
 '''
 
 
+import json
 import os
 
 from flask import (
@@ -39,8 +40,8 @@ def load_geojson(filename):
 
 @api_bp.route('/auth/google/callback', methods=['GET'])
 def google_auth_callback():
-    flow = Flow.from_client_secrets_file(
-        os.path.join(app.instance_path, app.config['GOOGLE_CREDENTIALS_FILE']),
+    flow = Flow.from_client_config(
+        json.loads(os.getenv('GOOGLE_CREDENTIALS')),
         scopes=['https://www.googleapis.com/auth/photoslibrary.readonly'],
     )
 


### PR DESCRIPTION
Store credentials in environment variable only and use `Flow.from_client_config` instead of writing them to a file and `Flow.from_client_secrets_file`. This eliminates the need to store the credentials file in the instance directory but photo album data will still be cached there.